### PR TITLE
move dot-prop to > 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "array-ify": "^1.0.0",
-    "dot-prop": "^3.0.0"
+    "dot-prop": "^5.1.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
This is used across a few other packages and currently relies on a `dot-prop` version that has the following security vulnerability https://nvd.nist.gov/vuln/detail/CVE-2020-8116

This just ups the `dot-prop` version to >5.1.0.

I've ran the tests and everything looks fine.

This is dependent on being rebased after https://github.com/stevemao/compare-func/pull/4 has been merged.