### PR TITLE
stop mocha from using latest *

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "istanbul": "^0.4.4",
     "jscs": "^3.0.5",
     "jshint": "^2.7.0",
-    "mocha": "*"
+    "mocha": "^2.5.1"
   },
   "scripts": {
     "coverage": "istanbul cover _mocha -- -R spec && rm -rf ./coverage",


### PR DESCRIPTION
tests are currently failing on CI due to using `*` as a version for `mocha` in `package.json`